### PR TITLE
atomic uint64 fix for arm

### DIFF
--- a/systree/types.go
+++ b/systree/types.go
@@ -25,8 +25,8 @@ type dynamicValue struct {
 }
 
 type dynamicValueInteger struct {
-	dynamicValue
 	val uint64
+	dynamicValue
 }
 
 type dynamicValueUpTime struct {


### PR DESCRIPTION
Atomic has a ["bug"](https://golang.org/pkg/sync/atomic/#pkg-note-BUG) when dealing with arm 
> On both ARM and x86-32, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

After this change it's possible to build and run VolantMQ on RPi for example. 