### PR TITLE
refactor: remove anonymous field from the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ plugins:
 #### Default auth config
 ```yaml
 auth:
-  anonymous: false # anonymous auth is prohibited. Listener can override
   order: # default auth order. Authenticators invoked in the order they present in the config. Listener can override
     - internal
 ```
@@ -157,12 +156,10 @@ listeners:
       1883:                # port number. can be as many ports configurations as needed
         host: 127.0.0.1    # optional. listen address. defaultAddr is used if omitted
         auth:              # optional. default auth configuration is used if omitted
-          anonymous: true  # optional. default auth configuration is used if omitted
           order:           # optional. default auth configuration is used if omitted
             - internal
       1884:
         auth:
-          anonymous: false
           order:
             - http1
         tls:               # TLS configuration

--- a/auth/manager_test.go
+++ b/auth/manager_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/VolantMQ/vlapi/vlauth"
+	"github.com/stretchr/testify/require"
+)
+
+type testAuth struct {
+	creds map[string]string
+}
+
+var _ vlauth.IFace = (*testAuth)(nil)
+
+func newSimpleAuth() *testAuth {
+	return &testAuth{
+		creds: map[string]string{
+			"testuser": "9f735e0df9a1ddc702bf0a1a7b83033f9f7153a00c29de82cedadc9957289b05",
+		},
+	}
+}
+
+func (a *testAuth) Password(_, user, password string) error {
+	if hash, ok := a.creds[user]; ok {
+		algo := sha256.New()
+		if _, err := algo.Write([]byte(password)); err == nil {
+			if hex.EncodeToString(algo.Sum(nil)) == hash {
+				return vlauth.StatusAllow
+			}
+		}
+	}
+	return vlauth.StatusDeny
+}
+
+func (a *testAuth) ACL(_, _, _ string, acl vlauth.AccessType) error {
+	if acl == vlauth.AccessWrite {
+		return vlauth.StatusDeny
+	}
+
+	return vlauth.StatusAllow
+}
+
+func (a *testAuth) Shutdown() error {
+	a.creds = nil
+	return nil
+}
+
+func TestAuthRegister(t *testing.T) {
+	err := Register("basic", newSimpleAuth())
+	require.NoError(t, err)
+}
+
+func TestAuthRegisterDupe(t *testing.T) {
+	err := Register("basic", newSimpleAuth())
+	require.Error(t, err, "already exists")
+}
+
+func TestAuthRegisterInvalidArgs(t *testing.T) {
+	err := Register("", newSimpleAuth())
+	require.Error(t, err, "invalid args")
+
+	err = Register("basic", nil)
+	require.Error(t, err, "invalid args")
+}
+
+func TestNewManagerUnknownProvider(t *testing.T) {
+	p, err := NewManager([]string{"bla"})
+	require.Error(t, err)
+	require.Nil(t, p)
+}
+
+func TestNewManagerKnownProvider(t *testing.T) {
+	p, err := NewManager([]string{"basic"})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	acl, st := p.Password("", "testuser", "testpassword")
+	require.EqualError(t, st, vlauth.StatusAllow.Error())
+	require.NotNil(t, acl)
+
+	st = acl.ACL("", "testuser", "/topic", vlauth.AccessRead)
+	require.EqualError(t, st, vlauth.StatusAllow.Error())
+
+	st = acl.ACL("", "testuser", "/topic", vlauth.AccessWrite)
+	require.EqualError(t, st, vlauth.StatusDeny.Error())
+
+	acl, st = p.Password("", "", "")
+	require.EqualError(t, st, vlauth.StatusDeny.Error())
+	require.Nil(t, acl)
+
+	acl, st = p.Password("", "testuser", "testpassword1")
+	require.EqualError(t, st, vlauth.StatusDeny.Error())
+	require.Nil(t, acl)
+}
+
+func TestAuthUnregister(t *testing.T) {
+	UnRegister("basic")
+
+	p, err := NewManager([]string{"basic"})
+	require.Error(t, err)
+	require.Nil(t, p)
+}

--- a/cmd/volantmq/main.go
+++ b/cmd/volantmq/main.go
@@ -109,7 +109,7 @@ func loadMqttListeners(defaultAuth *auth.Manager, lCfg *configuration.ListenersC
 
 			if len(cfg.Auth.Order) > 0 {
 				var err error
-				if transportAuth, err = auth.NewManager(cfg.Auth.Order, cfg.Auth.Anonymous); err != nil {
+				if transportAuth, err = auth.NewManager(cfg.Auth.Order); err != nil {
 					return nil, err
 				}
 			}
@@ -330,7 +330,7 @@ func (ctx *appContext) loadAuth(cfg *configuration.Config) (*auth.Manager, error
 		}
 	}
 
-	def, err := auth.NewManager(cfg.Auth.Order, cfg.Auth.Anonymous)
+	def, err := auth.NewManager(cfg.Auth.Order)
 
 	if err != nil {
 		logger.Error("\tcreating default auth:", err.Error())
@@ -338,7 +338,6 @@ func (ctx *appContext) loadAuth(cfg *configuration.Config) (*auth.Manager, error
 	}
 
 	logger.Info("\tdefault auth order: ", cfg.Auth.Order)
-	logger.Info("\tdefault auth anonymous: ", cfg.Auth.Anonymous)
 
 	return def, nil
 }

--- a/configuration/configTypes.go
+++ b/configuration/configTypes.go
@@ -100,8 +100,7 @@ type SecurityConfig struct {
 }
 
 type AuthConfig struct {
-	Anonymous bool     `yaml:"anonymous,omitempty" default:"false"`
-	Order     []string `yaml:"order"`
+	Order []string `yaml:"order"`
 }
 
 // PortConfig configuration of tcp/ssl/ws(s) listeners

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -119,7 +119,7 @@ func (s *Type) UnSubscribe(topic string) error {
 // Publish message accordingly to subscriber state
 // online: forward message to session
 // offline: persist message
-func (s *Type) Publish(p *mqttp.Publish, grantedQoS mqttp.QosType, ops mqttp.SubscriptionOptions, ids []uint32) error {
+func (s *Type) Publish(p *mqttp.Publish, grantedQoS mqttp.QosType, _ mqttp.SubscriptionOptions, ids []uint32) error {
 	select {
 	case <-s.quit:
 		return nil


### PR DESCRIPTION
after successful auth retain auth backend and pass it to connection
