### PR TITLE
[Fix] Sending blank username to ACL in onPublish

### DIFF
--- a/clients/sessions.go
+++ b/clients/sessions.go
@@ -417,7 +417,8 @@ func (m *Manager) newSession(cn connection.Initial, params *connection.ConnectPa
 
 		if cn.Acknowledge(ack,
 			connection.KeepAlive(keepAlive),
-			connection.Permissions(authMngr)) == nil {
+			connection.Permissions(authMngr),
+			connection.Username(string(params.Username))) == nil {
 
 			ses.start()
 

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -169,6 +169,7 @@ type SessionCallbacks interface {
 type impl struct {
 	SessionCallbacks
 	id               string
+	user             string
 	conn             transport.Conn
 	metric           metrics.Packets
 	permissions      vlauth.Permissions
@@ -428,6 +429,7 @@ func (s *impl) onConnect(pkt *mqttp.Connect) error {
 
 		params.Username, params.Password = pkt.Credentials()
 		s.version = params.Version
+		s.user = string(params.Username)
 
 		s.readConnProperties(pkt, params)
 
@@ -861,7 +863,7 @@ func (s *impl) onPublish(pkt *mqttp.Publish) (mqttp.IFace, error) {
 	//   - ignore the message but send acks
 	//   - return error leading to disconnect
 	// TODO: publish permissions
-	if e := s.permissions.ACL(s.id, "", pkt.Topic(), vlauth.AccessWrite); e != vlauth.StatusAllow {
+	if e := s.permissions.ACL(s.id, s.user, pkt.Topic(), vlauth.AccessWrite); e != vlauth.StatusAllow {
 		reason = mqttp.CodeRefusedNotAuthorized
 	}
 

--- a/connection/options.go
+++ b/connection/options.go
@@ -142,3 +142,10 @@ func Permissions(val vlauth.Permissions) Option {
 		return nil
 	}
 }
+
+func Username(val string) Option {
+	return func(t *impl) error {
+		t.user = val
+		return nil
+	}
+}


### PR DESCRIPTION
Attempt to fix #167 partially. Sending a blank username could be solved if we stored username in connection and setting it in newSession function.